### PR TITLE
Fix appcompat unsafe dependancy

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "androidx.appcompat:appcompat:+"
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
### What's the problem

The appcompat implementation on android has an unsafe dependency. When this dependency was updated it broke `TextInput` on Android.

### Solution

Change the dependency to a fixed value